### PR TITLE
Add DID wallet

### DIFF
--- a/src/main/java/org/medibloc/panacea/BaseWallet.java
+++ b/src/main/java/org/medibloc/panacea/BaseWallet.java
@@ -1,0 +1,65 @@
+package org.medibloc.panacea;
+
+
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.bitcoinj.core.ECKey;
+import org.medibloc.panacea.encoding.Crypto;
+import org.medibloc.panacea.encoding.EncodeUtils;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+
+@ToString
+class BaseWallet {
+    private final ECKey ecKey;
+
+    BaseWallet(String privateKey) {
+        if (!StringUtils.isEmpty(privateKey)) {
+            this.ecKey = ECKey.fromPrivate(new BigInteger(privateKey, 16));
+        } else {
+            throw new IllegalArgumentException("Private key cannot be empty.");
+        }
+    }
+
+    BaseWallet(byte[] pubKey) {
+        this.ecKey = ECKey.fromPublicOnly(pubKey);
+    }
+
+    public static List<String> mnemonicStringToWords(String mnemonic) {
+        return Arrays.asList(mnemonic.split("\\s+"));
+    }
+
+    public byte[] sign(byte[] data) throws IOException, NoSuchAlgorithmException {
+        return Crypto.sign(data, getEcKey());
+    }
+
+    public byte[] sign(Object object) throws IOException, NoSuchAlgorithmException {
+        byte[] data = EncodeUtils.toJsonEncodeBytes(object);
+        return sign(data);
+    }
+
+    @Deprecated
+    public String getPrivateKey() {
+        return getPrivateKeyHexString();
+    }
+
+    public ECKey getEcKey() {
+        return ecKey;
+    }
+
+    public String getPrivateKeyHexString() {
+        return ecKey.getPrivateKeyAsHex();
+    }
+
+    public String getPubKeyHexString() {
+        return ecKey.getPublicKeyAsHex();
+    }
+
+    public byte[] getPubKeyBytes() {
+        return ecKey.getPubKey();
+    }
+}

--- a/src/main/java/org/medibloc/panacea/DIDWallet.java
+++ b/src/main/java/org/medibloc/panacea/DIDWallet.java
@@ -1,0 +1,40 @@
+package org.medibloc.panacea;
+
+
+import lombok.ToString;
+import org.medibloc.panacea.encoding.Crypto;
+
+import java.util.List;
+
+@ToString
+public class DIDWallet extends BaseWallet {
+    private DIDWallet(String privateKey) {
+        super(privateKey);
+    }
+
+    public static DIDWallet createRandomWallet() {
+        return createWalletFromMnemonicCode(Crypto.generateMnemonicCode());
+    }
+
+    public static DIDWallet createWalletFromEntropy(byte[] entropy) {
+        return createWalletFromMnemonicCode(Crypto.generateMnemonicCodeFromEntropy(entropy));
+    }
+
+    public static DIDWallet createWalletFromMnemonicCode(String mnemonic) {
+        return createWalletFromMnemonicCode(mnemonic, 0);
+    }
+
+    public static DIDWallet createWalletFromMnemonicCode(List<String> words) {
+        return createWalletFromMnemonicCode(words, 0);
+    }
+
+    public static DIDWallet createWalletFromMnemonicCode(String mnemonic, int index) {
+        List<String> words = mnemonicStringToWords(mnemonic);
+        return createWalletFromMnemonicCode(words, index);
+    }
+
+    public static DIDWallet createWalletFromMnemonicCode(List<String> words, int index) {
+        String privateKey = Crypto.getPrivateKeyFromMnemonicCode(words, index);
+        return new DIDWallet(privateKey);
+    }
+}

--- a/src/main/java/org/medibloc/panacea/encoding/message/MsgCreateDID.java
+++ b/src/main/java/org/medibloc/panacea/encoding/message/MsgCreateDID.java
@@ -4,9 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.apache.commons.codec.binary.Base64;
+import org.medibloc.panacea.DIDWallet;
 import org.medibloc.panacea.encoding.message.did.DID;
 import org.medibloc.panacea.encoding.message.did.DIDDocument;
+import org.medibloc.panacea.encoding.message.did.DIDSignable;
 import org.medibloc.panacea.encoding.message.did.DIDVerificationMethod;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 @NoArgsConstructor
 @Getter
@@ -18,22 +24,31 @@ public class MsgCreateDID implements PanaceaTransactionMessage {
     private final String type = "did/MsgCreateDID";
     private Value value;
 
-    public MsgCreateDID(DID did, DIDDocument document, DIDVerificationMethod.ID verificationMethodId, String signatureBase64, String fromAddress) {
-        this.value = new Value(did, document, verificationMethodId, signatureBase64, fromAddress);
+    public MsgCreateDID(DID did, DIDDocument document, String fromAddress) {
+        this.value = new Value(did, document, fromAddress);
     }
 
-    @AllArgsConstructor
+    public void sign(DIDVerificationMethod.ID veriMethodId, DIDWallet wallet, Long sequence) throws IOException, NoSuchAlgorithmException {
+        byte[] sig = wallet.sign(new DIDSignable(this.value.getDocument(), sequence));
+        this.value.setSignatureBase64(Base64.encodeBase64String(sig));
+        this.value.setVerificationMethodId(veriMethodId);
+    }
+
+    @RequiredArgsConstructor
     @Getter
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonPropertyOrder(alphabetic = true)
     public static class Value {
+        @NonNull
         private DID did;
+        @NonNull
         private DIDDocument document;
         @JsonProperty("verification_method_id")
         private DIDVerificationMethod.ID verificationMethodId;
         @JsonProperty("signature")
         private String signatureBase64;
+        @NonNull
         @JsonProperty("from_address")
         private String fromAddress;
     }

--- a/src/main/java/org/medibloc/panacea/encoding/message/MsgDeactivateDID.java
+++ b/src/main/java/org/medibloc/panacea/encoding/message/MsgDeactivateDID.java
@@ -4,9 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.apache.commons.codec.binary.Base64;
+import org.medibloc.panacea.DIDWallet;
 import org.medibloc.panacea.encoding.message.did.DID;
-import org.medibloc.panacea.encoding.message.did.DIDDocument;
+import org.medibloc.panacea.encoding.message.did.DIDSignable;
 import org.medibloc.panacea.encoding.message.did.DIDVerificationMethod;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -19,21 +24,29 @@ public class MsgDeactivateDID implements PanaceaTransactionMessage {
     private final String type = "did/MsgDeleteDID";
     private Value value;
 
-    public MsgDeactivateDID(DID did, DIDVerificationMethod.ID verificationMethodId, String signatureBase64, String fromAddress) {
-        this.value = new MsgDeactivateDID.Value(did, verificationMethodId, signatureBase64, fromAddress);
+    public MsgDeactivateDID(DID did, String fromAddress) {
+        this.value = new Value(did, fromAddress);
     }
 
-    @AllArgsConstructor
+    public void sign(DIDVerificationMethod.ID veriMethodId, DIDWallet wallet, Long sequence) throws IOException, NoSuchAlgorithmException {
+        byte[] sig = wallet.sign(new DIDSignable(this.value.getDid(), sequence));
+        this.value.setSignatureBase64(Base64.encodeBase64String(sig));
+        this.value.setVerificationMethodId(veriMethodId);
+    }
+
+    @RequiredArgsConstructor
     @Getter
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonPropertyOrder(alphabetic = true)
     public static class Value {
+        @NonNull
         private DID did;
         @JsonProperty("verification_method_id")
         private DIDVerificationMethod.ID verificationMethodId;
         @JsonProperty("signature")
         private String signatureBase64;
+        @NonNull
         @JsonProperty("from_address")
         private String fromAddress;
     }

--- a/src/main/java/org/medibloc/panacea/encoding/message/MsgUpdateDID.java
+++ b/src/main/java/org/medibloc/panacea/encoding/message/MsgUpdateDID.java
@@ -4,9 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.apache.commons.codec.binary.Base64;
+import org.medibloc.panacea.DIDWallet;
 import org.medibloc.panacea.encoding.message.did.DID;
 import org.medibloc.panacea.encoding.message.did.DIDDocument;
+import org.medibloc.panacea.encoding.message.did.DIDSignable;
 import org.medibloc.panacea.encoding.message.did.DIDVerificationMethod;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 @NoArgsConstructor
 @Getter
@@ -18,22 +24,31 @@ public class MsgUpdateDID implements PanaceaTransactionMessage {
     private final String type = "did/MsgUpdateDID";
     private Value value;
 
-    public MsgUpdateDID(DID did, DIDDocument document, DIDVerificationMethod.ID verificationMethodId, String signatureBase64, String fromAddress) {
-        this.value = new Value(did, document, verificationMethodId, signatureBase64, fromAddress);
+    public MsgUpdateDID(DID did, DIDDocument document, String fromAddress) {
+        this.value = new MsgUpdateDID.Value(did, document, fromAddress);
     }
 
-    @AllArgsConstructor
+    public void sign(DIDVerificationMethod.ID veriMethodId, DIDWallet wallet, Long sequence) throws IOException, NoSuchAlgorithmException {
+        byte[] sig = wallet.sign(new DIDSignable(this.value.getDocument(), sequence));
+        this.value.setSignatureBase64(Base64.encodeBase64String(sig));
+        this.value.setVerificationMethodId(veriMethodId);
+    }
+
+    @RequiredArgsConstructor
     @Getter
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonPropertyOrder(alphabetic = true)
     public static class Value {
+        @NonNull
         private DID did;
+        @NonNull
         private DIDDocument document;
         @JsonProperty("verification_method_id")
         private DIDVerificationMethod.ID verificationMethodId;
         @JsonProperty("signature")
         private String signatureBase64;
+        @NonNull
         @JsonProperty("from_address")
         private String fromAddress;
     }

--- a/src/main/java/org/medibloc/panacea/encoding/message/did/DIDSignable.java
+++ b/src/main/java/org/medibloc/panacea/encoding/message/did/DIDSignable.java
@@ -20,9 +20,5 @@ public class DIDSignable {
     @JsonSerialize(using = ToStringSerializer.class)  // NOTE: The String->Long deserialization is done automatically
     private final Long sequence;
 
-    private static final Long initialSequence = 0L;
-
-    public DIDSignable(Object data) {
-        this(data, initialSequence);
-    }
+    public static final Long initialSequence = 0L;
 }

--- a/src/test/java/org/medibloc/panacea/WalletTest.java
+++ b/src/test/java/org/medibloc/panacea/WalletTest.java
@@ -3,8 +3,8 @@ package org.medibloc.panacea;
 import org.bitcoinj.core.ECKey;
 import org.junit.Test;
 import org.medibloc.panacea.encoding.Crypto;
+import org.medibloc.panacea.encoding.EncodeUtils;
 import org.medibloc.panacea.encoding.message.Pubkey;
-import org.spongycastle.util.Strings;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -24,8 +24,11 @@ public class WalletTest {
 
     @Test
     public void signViaPrivKey() throws IOException, NoSuchAlgorithmException {
-        byte[] data = Strings.toByteArray("hello");
-        byte[] expectedSig = Crypto.sign(data, ECKey.fromPrivate(new BigInteger(privKeyHex, 16)));
+        String data = "hello";
+        byte[] expectedSig = Crypto.sign(
+                EncodeUtils.toJsonEncodeBytes(data),
+                ECKey.fromPrivate(new BigInteger(privKeyHex, 16))
+        );
 
         Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
         assertArrayEquals(expectedSig, wallet.sign(data));

--- a/src/test/java/org/medibloc/panacea/WalletTest.java
+++ b/src/test/java/org/medibloc/panacea/WalletTest.java
@@ -1,0 +1,66 @@
+package org.medibloc.panacea;
+
+import org.bitcoinj.core.ECKey;
+import org.junit.Test;
+import org.medibloc.panacea.encoding.Crypto;
+import org.medibloc.panacea.encoding.message.Pubkey;
+import org.spongycastle.util.Strings;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.Assert.*;
+
+public class WalletTest {
+    // test data
+    private static final String hrp = "panacea";
+    private static final String mnemonic = "benefit draft eye juice custom short project alone churn boss program tackle tobacco update chimney";
+    private static final String privKeyHex = "1f93bd070c548d1b4f80afb0cce311f45146ab75ab6b944f0db3dbd496822436";
+    private static final String pubKeyForSign = "A+Di0Y5PBFyCCuWrzKRPsnrte9SR/Qe0XeWPed1vkvIS\r\n";
+    private static final String pubKeyBech32 = "panaceapub1addwnpepq0sw95vwfuz9eqs2uk4uefz0kfaw6775j87s0dzauk8hnht0jtepyshtrwg";
+    private static final String pubKeyHex = "03e0e2d18e4f045c820ae5abcca44fb27aed7bd491fd07b45de58f79dd6f92f212";
+    private static final String address = "panacea19ca5yrl6av7fu63rcg26mq3s7dhc57fhqg5x5g";
+
+    @Test
+    public void signViaPrivKey() throws IOException, NoSuchAlgorithmException {
+        byte[] data = Strings.toByteArray("hello");
+        byte[] expectedSig = Crypto.sign(data, ECKey.fromPrivate(new BigInteger(privKeyHex, 16)));
+
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        assertArrayEquals(expectedSig, wallet.sign(data));
+    }
+
+    @Test
+    public void getPrivateKeyHexString() {
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        assertEquals(privKeyHex, wallet.getPrivateKey());
+        assertEquals(privKeyHex, wallet.getPrivateKeyHexString());
+    }
+
+    @Test
+    public void getAddress() {
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        assertEquals(address, wallet.getAddress());
+    }
+
+    @Test
+    public void getPubKeyForSign() {
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        Pubkey pub = wallet.getPubKeyForSign();
+        assertEquals(pubKeyForSign, pub.getValue());
+    }
+
+    @Test
+    public void getPubKeyBech32() {
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        assertEquals(pubKeyBech32, wallet.getPubKey());
+        assertEquals(pubKeyBech32, wallet.getPubKeyBech32());
+    }
+
+    @Test
+    public void getPubKeyHexString() {
+        Wallet wallet = Wallet.createWalletFromMnemonicCode(mnemonic, hrp);
+        assertEquals(pubKeyHex, wallet.getPubKeyHexString());
+    }
+}


### PR DESCRIPTION
Merge to #4 

FYI, the key-pairs for DID are independent with the key-pairs of Panacea accounts.

For usability,
I defined the `DIDWallet` class similar as `Wallet` which has been for the Panacea account.
I keep the name `Wallet` for backward compatibility, but I defined a super class `BaseWallet` and moved some logic to it.

![image](https://user-images.githubusercontent.com/5462944/93573178-c5c93380-f9d1-11ea-9c58-3258a9e79527.png)
