### PR TITLE
feat: Add a factory of DidDocument

### DIFF
--- a/src/main/java/org/medibloc/panacea/encoding/message/did/DidDocument.java
+++ b/src/main/java/org/medibloc/panacea/encoding/message/did/DidDocument.java
@@ -2,7 +2,10 @@ package org.medibloc.panacea.encoding.message.did;
 
 import com.fasterxml.jackson.annotation.*;
 import lombok.*;
+import org.medibloc.panacea.DidWallet;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
@@ -34,5 +37,29 @@ public class DidDocument {
 
         @JsonValue
         private final String value;
+    }
+
+    /**
+     * Create a simple DID Document
+     * @param didWallet DID Wallet
+     * @return DID Document
+     * @throws NoSuchAlgorithmException
+     */
+    public static DidDocument create(DidWallet didWallet) throws NoSuchAlgorithmException {
+        byte[] pubKey = didWallet.getPubKeyBytes();
+
+        Did did = new Did(pubKey);
+        DidVerificationMethod veriMethod = new DidVerificationMethod(
+                new DidVerificationMethod.Id(did, "key1"),
+                DidKeyType.ES256K,
+                did,
+                pubKey
+        );
+        return new DidDocument(
+                Collections.singletonList(Context.DID_V1),
+                did,
+                Collections.singletonList(veriMethod),
+                Collections.singletonList((DidAuthentication) new DidVeriMethodIdAuthentication(veriMethod.getId()))
+        );
     }
 }


### PR DESCRIPTION
As a helper, I implemented a `DidDocument.create(DidWallet)` factory which creates a basic DID Document (which holds minimum fields).
(That's what the `panaceacli tx did create-did ...` does.)