### PR TITLE
Release v0.1.2 + Rename package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@
 
 TBD
 
-## [v0.1.1](https://github.com/medibloc/medibloc-panacea-api/releases/tag/v0.1.1) - 2021-01-07
-
-- [\#17](https://github.com/medibloc/medibloc-panacea-api/pull/17) Escape HTML characters for JSON marshalling when signing on transactions
-
-## [v0.1.0](https://github.com/medibloc/medibloc-panacea-api/releases/tag/v0.1.0) - 2020-11-02
+## [v0.1.2](https://github.com/medibloc/panacea-java/releases/tag/v0.1.2) - 2021-01-26
 
 ### Features
 
-- [\#4](https://github.com/medibloc/medibloc-panacea-api/pull/4), [\#7](https://github.com/medibloc/medibloc-panacea-api/pull/7), [\#11](https://github.com/medibloc/medibloc-panacea-api/pull/11) Support DID operations
-- [\#9](https://github.com/medibloc/medibloc-panacea-api/pull/9) Follow up the new Cosmos v0.36.0+ REST specs 
+- [\#19](https://github.com/medibloc/panacea-java/pull/19) feat: Add a factory of DidDocument
+
+
+## [v0.1.1](https://github.com/medibloc/panacea-java/releases/tag/v0.1.1) - 2021-01-07
+
+### Features
+
+- [\#17](https://github.com/medibloc/panacea-java/pull/17) Escape HTML characters for JSON marshalling when signing on transactions
+
+
+## [v0.1.0](https://github.com/medibloc/panacea-java/releases/tag/v0.1.0) - 2020-11-02
+
+### Features
+
+- [\#4](https://github.com/medibloc/panacea-java/pull/4), [\#7](https://github.com/medibloc/panacea-java/pull/7), [\#11](https://github.com/medibloc/panacea-java/pull/11) Support DID operations
+- [\#9](https://github.com/medibloc/panacea-java/pull/9) Follow up the new Cosmos v0.36.0+ REST specs 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# medibloc-panacea-api
+# Panacea Java SDK
+
+## Installation
+
+### Gradle
+
+```gradle
+repositories {
+    maven {
+        url = "https://maven.pkg.github.com/medibloc/panacea-java"
+        // GitHub Packages credentials
+        credentials {
+            username = System.getenv("GPR_USER")
+            password = System.getenv("GPR_API_KEY")
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile group: 'org.medibloc.panacea', name: 'panacea-java', version: '0.1.2'
+}
+```
+
+## Examples
+
+- [PanaceaApiRestClientTest](src/test/java/org/medibloc/panacea/PanaceaApiRestClientTest.java)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.medibloc.panacea'
-version '0.1.1'
+version '0.1.2'
 
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
@@ -36,7 +36,7 @@ test {
 publishing {
     repositories {
         maven {
-            url = uri("https://maven.pkg.github.com/medibloc/medibloc-panacea-api")
+            url = uri("https://maven.pkg.github.com/medibloc/panacea-java")
             credentials {
                 username = System.getenv("GPR_USER")
                 password = System.getenv("GPR_API_KEY")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'medibloc-panacea-api'
+rootProject.name = 'panacea-java'
 


### PR DESCRIPTION
- Renamed the Github repo: `medibloc-panacea-api` -> `panacea-java`
- Renamed Github Package: `org.medibloc.panacea.medibloc-panacea-api` -> `org.medibloc.panacea.panacea-java`
- Release v0.1.2