### PR TITLE
test: Test AOL AddRecord with the broadcast mode `sync`

### DIFF
--- a/src/test/java/org/medibloc/panacea/GrpcAolTest.java
+++ b/src/test/java/org/medibloc/panacea/GrpcAolTest.java
@@ -153,7 +153,9 @@ public class GrpcAolTest extends AbstractGrpcTest {
                 System.out.println("offset: " + msgRes.getOffset());
                 break;
             } catch (StatusRuntimeException e) {
-                if (e.getStatus().getCode().equals(Status.Code.INVALID_ARGUMENT)) { // if tx was not found (if tx isn't included in the block yet)
+                // if tx was not found (if tx isn't included in the block yet)
+                // Misc: Yeah. I know that the status code INVALID_ARGUMENT isn't proper, but it's the way how Cosmos was implemented.
+                if (e.getStatus().getCode().equals(Status.Code.INVALID_ARGUMENT)) {
                     Thread.sleep(1000);
                     continue;
                 }

--- a/src/test/java/org/medibloc/panacea/GrpcAolTest.java
+++ b/src/test/java/org/medibloc/panacea/GrpcAolTest.java
@@ -8,7 +8,6 @@ import cosmos.tx.v1beta1.BroadcastTxRequest;
 import cosmos.tx.v1beta1.Fee;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
@@ -25,7 +24,7 @@ import java.util.List;
 public class GrpcAolTest extends AbstractGrpcTest {
 
     @Test
-    public void testAol() throws IOException, NoSuchAlgorithmException, PanaceaApiException, InterruptedException, DecoderException {
+    public void testAol() throws Exception {
         Wallet ownerWallet = getWallet(TestConst.ownerMnemonic);
         String ownerAddress = ownerWallet.getAddress();
         Wallet toWallet = getWallet(TestConst.toMnemonic);
@@ -124,7 +123,7 @@ public class GrpcAolTest extends AbstractGrpcTest {
         Assert.assertEquals(0, response.getCode());
     }
 
-    private void testAddRecord(MsgAddRecord msg, long expectedOffset) throws PanaceaApiException, IOException, NoSuchAlgorithmException, InterruptedException, DecoderException {
+    private void testAddRecord(MsgAddRecord msg, long expectedOffset) throws Exception {
         String memo = "add record";
         List<Wallet> groupSignWallets = Arrays.asList(
                 getWallet(TestConst.toMnemonic), getWallet(TestConst.ownerMnemonic));
@@ -142,26 +141,30 @@ public class GrpcAolTest extends AbstractGrpcTest {
         Assert.assertNotNull(response.getTxhash());
         Assert.assertEquals(0, response.getCode());
 
-        String txHash = response.getTxhash();
+        response = pollTxResponse(response.getTxhash(), 10, 1000);
+        TxMsgData txMsgData = TxMsgData.parseFrom(Hex.decodeHex(response.getData()));
+        MsgAddRecordResponse msgRes = MsgAddRecordResponse.parseFrom(txMsgData.getData(0).getData());
+        Assert.assertEquals(expectedOffset, msgRes.getOffset());
+    }
 
-        while (true) {
+    private TxResponse pollTxResponse(String txHash, int maxTries, int sleepMs) throws Exception {
+        // This test code does polling to wait until the tx is included in the block.
+        // But, in real world, pls use more fancy ways such as async jobs.
+        for (int tries = 0; tries < maxTries; tries++) {
             try {
-                response = client.getTxResponse(txHash);
-
-                TxMsgData txMsgData = TxMsgData.parseFrom(Hex.decodeHex(response.getData()));
-                MsgAddRecordResponse msgRes = MsgAddRecordResponse.parseFrom(txMsgData.getData(0).getData());
-                Assert.assertEquals(expectedOffset, msgRes.getOffset());
-                break;
+                return client.getTxResponse(txHash);
             } catch (StatusRuntimeException e) {
                 // if tx was not found (if tx isn't included in the block yet)
                 // Misc: Yeah. I know that the status code INVALID_ARGUMENT isn't proper, but it's the way how Cosmos was implemented.
                 if (e.getStatus().getCode().equals(Status.Code.INVALID_ARGUMENT)) {
-                    Thread.sleep(1000);
+                    Thread.sleep(sleepMs);
                     continue;
                 }
                 throw e;
             }
         }
+
+        throw new Exception("tx not found. maxTries: " + maxTries);
     }
 
     private void testGetTopic(String topicName, long totalWriters, long totalRecords, String description) throws PanaceaApiException {

--- a/src/test/java/org/medibloc/panacea/GrpcAolTest.java
+++ b/src/test/java/org/medibloc/panacea/GrpcAolTest.java
@@ -1,15 +1,17 @@
 package org.medibloc.panacea;
 
 import com.google.protobuf.ByteString;
+import cosmos.base.abci.v1beta1.TxMsgData;
 import cosmos.base.abci.v1beta1.TxResponse;
 import cosmos.tx.v1beta1.BroadcastMode;
 import cosmos.tx.v1beta1.BroadcastTxRequest;
 import cosmos.tx.v1beta1.Fee;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.medibloc.panacea.domain.Coins;
 import org.medibloc.panacea.domain.Transactions;
@@ -23,7 +25,7 @@ import java.util.List;
 public class GrpcAolTest extends AbstractGrpcTest {
 
     @Test
-    public void testAol() throws IOException, NoSuchAlgorithmException, PanaceaApiException {
+    public void testAol() throws IOException, NoSuchAlgorithmException, PanaceaApiException, InterruptedException, DecoderException {
         Wallet ownerWallet = getWallet(TestConst.ownerMnemonic);
         String ownerAddress = ownerWallet.getAddress();
         Wallet toWallet = getWallet(TestConst.toMnemonic);
@@ -122,7 +124,7 @@ public class GrpcAolTest extends AbstractGrpcTest {
         Assert.assertEquals(0, response.getCode());
     }
 
-    private void testAddRecord(MsgAddRecord msg) throws PanaceaApiException, IOException, NoSuchAlgorithmException {
+    private void testAddRecord(MsgAddRecord msg) throws PanaceaApiException, IOException, NoSuchAlgorithmException, InterruptedException, DecoderException {
         String memo = "add record";
         List<Wallet> groupSignWallets = Arrays.asList(
                 getWallet(TestConst.toMnemonic), getWallet(TestConst.ownerMnemonic));
@@ -133,12 +135,31 @@ public class GrpcAolTest extends AbstractGrpcTest {
                 msg,
                 memo,
                 fee,
-                BroadcastMode.BROADCAST_MODE_BLOCK);
+                BroadcastMode.BROADCAST_MODE_SYNC);  // Used the sync mode as an example
 
         TxResponse response = client.broadcast(request);
         System.out.println(response.toString());
         Assert.assertNotNull(response.getTxhash());
         Assert.assertEquals(0, response.getCode());
+
+        String txHash = response.getTxhash();
+
+        while (true) {
+            try {
+                response = client.getTxResponse(txHash);
+
+                TxMsgData txMsgData = TxMsgData.parseFrom(Hex.decodeHex(response.getData()));
+                MsgAddRecordResponse msgRes = MsgAddRecordResponse.parseFrom(txMsgData.getData(0).getData());
+                System.out.println("offset: " + msgRes.getOffset());
+                break;
+            } catch (StatusRuntimeException e) {
+                if (e.getStatus().getCode().equals(Status.Code.INVALID_ARGUMENT)) { // if tx was not found (if tx isn't included in the block yet)
+                    Thread.sleep(1000);
+                    continue;
+                }
+                throw e;
+            }
+        }
     }
 
     private void testGetTopic(String topicName, long totalWriters, long totalRecords, String description) throws PanaceaApiException {

--- a/src/test/java/org/medibloc/panacea/GrpcAolTest.java
+++ b/src/test/java/org/medibloc/panacea/GrpcAolTest.java
@@ -61,7 +61,7 @@ public class GrpcAolTest extends AbstractGrpcTest {
                 .setWriterAddress(ownerAddress)
                 .setFeePayerAddress(toAddress)
                 .build();
-        testAddRecord(addRecordMsg);
+        testAddRecord(addRecordMsg, 0);
         testGetTopic(topicName, 1, 1, createTopicMsg.getDescription());
 
         MsgDeleteWriter deleteWriteMsg = MsgDeleteWriter.newBuilder()
@@ -124,7 +124,7 @@ public class GrpcAolTest extends AbstractGrpcTest {
         Assert.assertEquals(0, response.getCode());
     }
 
-    private void testAddRecord(MsgAddRecord msg) throws PanaceaApiException, IOException, NoSuchAlgorithmException, InterruptedException, DecoderException {
+    private void testAddRecord(MsgAddRecord msg, long expectedOffset) throws PanaceaApiException, IOException, NoSuchAlgorithmException, InterruptedException, DecoderException {
         String memo = "add record";
         List<Wallet> groupSignWallets = Arrays.asList(
                 getWallet(TestConst.toMnemonic), getWallet(TestConst.ownerMnemonic));
@@ -150,7 +150,7 @@ public class GrpcAolTest extends AbstractGrpcTest {
 
                 TxMsgData txMsgData = TxMsgData.parseFrom(Hex.decodeHex(response.getData()));
                 MsgAddRecordResponse msgRes = MsgAddRecordResponse.parseFrom(txMsgData.getData(0).getData());
-                System.out.println("offset: " + msgRes.getOffset());
+                Assert.assertEquals(expectedOffset, msgRes.getOffset());
                 break;
             } catch (StatusRuntimeException e) {
                 // if tx was not found (if tx isn't included in the block yet)


### PR DESCRIPTION
As we're gonna increase the `timeout_commit` from 1s to 5s, using the broadcast mode `block` would causes more blocking times. 
As the suggestion from Cosmos, let's recommend users to use the broadcast mode `sync`.
Then, they should wait until the tx is included in a block if necessary. For example, users who execute AOL AddRecord transactions usually want to get the offset of record from its TxResponse. In this case, they must wait until the tx is finalized. 

So, I modified our test codes to show users how to wait for the tx finalization.